### PR TITLE
fixed the docker issue with execute rights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ USER root
 
 WORKDIR /opt/irisapp
 RUN chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp
+COPY irissession.sh /
+RUN chmod +x /irissession.sh 
 
 USER irisowner
 
 COPY  Installer.cls .
 COPY  src src
-COPY irissession.sh /
 SHELL ["/irissession.sh"]
 
 RUN \


### PR DESCRIPTION
You lost execute flag somehow for the shell file. 
So it doesn't work in a docker anymore with the bug:

ERROR: Service 'iris' failed to build: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/irissession.sh\": permission denied": unknown

Maybe you lost it while copying files on Windows. I'll change all the templates accordingly to avoid the problem in the future.
Accept the PR :)